### PR TITLE
chore: rename fork to lndk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,26 +177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fedimint-tonic-lnd"
-version = "0.1.3"
-dependencies = [
- "hex",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "prost",
- "rustls",
- "rustls-pemfile",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +447,26 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lndk-tonic-lnd"
+version = "0.1.3"
+dependencies = [
+ "hex",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "prost",
+ "rustls",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-tonic-lnd"
+name = "lndk-tonic-lnd"
 version = "0.1.3"
 edition = "2021"
 rust-version = "1.65.0"
 description = "An async library implementing LND RPC via tonic and prost. Forked from https://github.com/Kixunil/tonic_lnd"
-homepage = "https://github.com/fedimint/tonic_lnd"
-repository = "https://github.com/fedimint/tonic_lnd"
+homepage = "https://github.com/lndk-org/tonic_lnd"
+repository = "https://github.com/lndk-org/tonic_lnd"
 readme = "README.md"
 keywords = ["LND", "rpc", "grpc", "tonic", "async"]
 categories = [

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tonic LND client
 
-[![Crate](https://img.shields.io/crates/v/fedimint-tonic-lnd.svg?logo=rust)](https://crates.io/crates/fedimint-tonic-lnd)
-[![Documentation](https://img.shields.io/static/v1?logo=read-the-docs&label=docs.rs&message=fedimint-tonic-lnd&color=informational)](https://docs.rs/fedimint-tonic-lnd/)
+[![Crate](https://img.shields.io/crates/v/lndk-tonic-lnd.svg?logo=rust)](https://crates.io/crates/lndk-tonic-lnd)
+[![Documentation](https://img.shields.io/static/v1?logo=read-the-docs&label=docs.rs&message=lndk-tonic-lnd&color=informational)](https://docs.rs/lndk-tonic-lnd/)
 
 Rust implementation of LND RPC client using async gRPC library `tonic`.
 
@@ -10,11 +10,11 @@ Rust implementation of LND RPC client using async gRPC library `tonic`.
 **Warning: this crate is in early development and may have unknown problems!
 Review it before using with mainnet funds!**
 
-This crate supports *[Lightning](https://lightning.engineering/api-docs/category/lightning-service)*, *[WalletKit](https://lightning.engineering/api-docs/category/walletkit-service)*, *[Signer](https://lightning.engineering/api-docs/category/signer-service)*, and *[Peer](https://lightning.engineering/api-docs/category/peers-service)* RPC APIs from LND [v0.15.4-beta](https://github.com/lightningnetwork/lnd/tree/v0.15.4-beta)
+This crate supports _[Lightning](https://lightning.engineering/api-docs/category/lightning-service)_, _[WalletKit](https://lightning.engineering/api-docs/category/walletkit-service)_, _[Signer](https://lightning.engineering/api-docs/category/signer-service)_, and _[Peer](https://lightning.engineering/api-docs/category/peers-service)_ RPC APIs from LND [v0.15.4-beta](https://github.com/lightningnetwork/lnd/tree/v0.15.4-beta)
 
 This crate implements LND GRPC using [`tonic`](https://docs.rs/tonic/) and [`prost`](https://docs.rs/prost/).
 Apart from being up-to-date at the time of writing (:D) it also allows `async` usage.
-It contains vendored `*.proto` files so LND source code is not *required*
+It contains vendored `*.proto` files so LND source code is not _required_
 but accepts an environment variable `LND_REPO_DIR` which overrides the vendored `*.proto` files.
 This can be used to test new features in non-released `lnd`.
 (Actually, the motivating project using this library was that case. :))
@@ -47,14 +47,14 @@ async fn main() {
     let address = address.into_string().expect("address is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = lndk_tonic_lnd::connect(address, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
     let info = client
         .lightning()
         // All calls require at least empty parameter
-        .get_info(fedimint_tonic_lnd::lnrpc::GetInfoRequest {})
+        .get_info(lndk_tonic_lnd::lnrpc::GetInfoRequest {})
         .await
         .expect("failed to get info");
 

--- a/examples/cancel_invoice.rs
+++ b/examples/cancel_invoice.rs
@@ -34,13 +34,13 @@ async fn main() {
     .expect("payment_hash is not a valid hex");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = lndk_tonic_lnd::connect(address, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
     client
         .invoices()
-        .cancel_invoice(fedimint_tonic_lnd::invoicesrpc::CancelInvoiceMsg { payment_hash })
+        .cancel_invoice(lndk_tonic_lnd::invoicesrpc::CancelInvoiceMsg { payment_hash })
         .await
         .expect("Failed to cancel invoice");
 

--- a/examples/get_info.rs
+++ b/examples/get_info.rs
@@ -21,18 +21,18 @@ async fn main() {
     let address = address.into_string().expect("address is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = lndk_tonic_lnd::connect(address, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
     let info = client
         .lightning()
         // All calls require at least empty parameter
-        .get_info(fedimint_tonic_lnd::lnrpc::GetInfoRequest {})
+        .get_info(lndk_tonic_lnd::lnrpc::GetInfoRequest {})
         .await
         .expect("failed to get info");
 
     // We only print it here, note that in real-life code you may want to call `.into_inner()` on
     // the response to get the message.
-    println!("{:#?}", info);
+    println!("{info:#?}");
 }

--- a/examples/get_version.rs
+++ b/examples/get_version.rs
@@ -20,16 +20,16 @@ async fn main() {
     let address = address.into_string().expect("address is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = lndk_tonic_lnd::connect(address, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
     let version = client
         .versioner()
-        .get_version(fedimint_tonic_lnd::verrpc::VersionRequest {})
+        .get_version(lndk_tonic_lnd::verrpc::VersionRequest {})
         .await
         .expect("failed to get version");
     // We only print it here, note that in real-life code you may want to call `.into_inner()` on
     // the response to get the message.
-    println!("{:#?}", version);
+    println!("{version:#?}");
 }

--- a/examples/intercept_htlcs.rs
+++ b/examples/intercept_htlcs.rs
@@ -29,13 +29,12 @@ async fn main() {
         .expect("macaroon_file is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = lndk_tonic_lnd::connect(address, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
-    let (tx, rx) = tokio::sync::mpsc::channel::<
-        fedimint_tonic_lnd::routerrpc::ForwardHtlcInterceptResponse,
-    >(1024);
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<lndk_tonic_lnd::routerrpc::ForwardHtlcInterceptResponse>(1024);
     let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
 
     let mut htlc_stream = client
@@ -56,7 +55,7 @@ async fn main() {
             htlc.incoming_circuit_key, htlc.incoming_amount_msat, htlc.outgoing_amount_msat, htlc.payment_hash
         );
 
-        let response = fedimint_tonic_lnd::routerrpc::ForwardHtlcInterceptResponse {
+        let response = lndk_tonic_lnd::routerrpc::ForwardHtlcInterceptResponse {
             incoming_circuit_key: htlc.incoming_circuit_key,
             action: 2, // Resume fordwarding of intercepted HTLC
             preimage: vec![],

--- a/examples/subscribe_invoices.rs
+++ b/examples/subscribe_invoices.rs
@@ -20,13 +20,13 @@ async fn main() {
     let address = address.into_string().expect("address is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = lndk_tonic_lnd::connect(address, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
     let mut invoice_stream = client
         .lightning()
-        .subscribe_invoices(fedimint_tonic_lnd::lnrpc::InvoiceSubscription {
+        .subscribe_invoices(lndk_tonic_lnd::lnrpc::InvoiceSubscription {
             add_index: 0,
             settle_index: 0,
         })
@@ -39,14 +39,14 @@ async fn main() {
         .await
         .expect("Failed to receive invoices")
     {
-        let state: fedimint_tonic_lnd::lnrpc::invoice::InvoiceState = invoice
+        let state: lndk_tonic_lnd::lnrpc::invoice::InvoiceState = invoice
             .state
             .try_into()
             .expect("Failed to parse invoice state");
 
         // If this invoice was Settled we can do something with it
-        if state == fedimint_tonic_lnd::lnrpc::invoice::InvoiceState::Settled {
-            println!("{:?}", invoice);
+        if state == lndk_tonic_lnd::lnrpc::invoice::InvoiceState::Settled {
+            println!("{invoice:?}");
         }
     }
 }

--- a/examples/track_payment.rs
+++ b/examples/track_payment.rs
@@ -34,13 +34,13 @@ async fn main() {
     .expect("payment_hash is not a valid hex");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = lndk_tonic_lnd::connect(address, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
     let response = client
         .router()
-        .track_payment(fedimint_tonic_lnd::routerrpc::TrackPaymentRequest {
+        .track_payment(lndk_tonic_lnd::routerrpc::TrackPaymentRequest {
             payment_hash,
             no_inflight_updates: false,
         })
@@ -53,7 +53,7 @@ async fn main() {
         .await
         .expect("Failed to get payment")
     {
-        println!("{:?}", payment);
+        println!("{payment:?}");
     } else {
         println!("Payment not found");
     }


### PR DESCRIPTION
As we are adding changes, we don't need to keep the "fedimint" prefix on this fork.  