### PR TITLE
fix: track payment example use v2

### DIFF
--- a/examples/track_payment.rs
+++ b/examples/track_payment.rs
@@ -40,7 +40,7 @@ async fn main() {
 
     let response = client
         .router()
-        .track_payment(lndk_tonic_lnd::routerrpc::TrackPaymentRequest {
+        .track_payment_v2(lndk_tonic_lnd::routerrpc::TrackPaymentRequest {
             payment_hash,
             no_inflight_updates: false,
         })


### PR DESCRIPTION
previous one was deprecated, clippy flagged on merge CI checks